### PR TITLE
feat: Implement forgot password functionality

### DIFF
--- a/auth/auth.py
+++ b/auth/auth.py
@@ -1,9 +1,18 @@
-from flask import Blueprint, render_template, redirect, url_for, flash
+from flask import Blueprint, render_template, redirect, url_for, flash, request
 from flask_login import login_user, logout_user, login_required
 from werkzeug.security import generate_password_hash, check_password_hash
 from models import User
-from forms import LoginForm, SignupForm
+from forms import LoginForm, SignupForm, ForgotPasswordForm, ResetPasswordForm
 from app import db
+
+def send_password_reset_email(user):
+    token = user.get_reset_token()
+    # In a real app, you would use a service like Flask-Mail to send an email.
+    # For this example, we'll just print the link to the console.
+    reset_link = url_for('auth.reset_password', token=token, _external=True)
+    print("------- PASSWORD RESET LINK -------")
+    print(f"Click the following link to reset your password: {reset_link}")
+    print("---------------------------------")
 
 bp = Blueprint('auth', __name__, url_prefix='/auth')
 
@@ -41,3 +50,31 @@ def login():
 def logout():
     logout_user()
     return redirect(url_for('main.index'))
+
+@bp.route('/forgot-password', methods=['GET', 'POST'])
+def forgot_password():
+    form = ForgotPasswordForm()
+    if form.validate_on_submit():
+        user = User.query.filter_by(email=form.email.data).first()
+        if user:
+            send_password_reset_email(user)
+        flash('If an account with that email exists, a password reset link has been sent.', 'info')
+        return redirect(url_for('auth.login'))
+    return render_template('auth/forgot_password.html', title='Forgot Password', form=form)
+
+@bp.route('/reset-password/<token>', methods=['GET', 'POST'])
+def reset_password(token):
+    user = User.verify_reset_token(token)
+    if not user:
+        flash('That is an invalid or expired token.', 'warning')
+        return redirect(url_for('auth.forgot_password'))
+
+    form = ResetPasswordForm()
+    if form.validate_on_submit():
+        hashed_password = generate_password_hash(form.password.data)
+        user.password = hashed_password
+        db.session.commit()
+        flash('Your password has been updated! You are now able to log in.', 'success')
+        return redirect(url_for('auth.login'))
+
+    return render_template('auth/reset_password.html', title='Reset Password', form=form)

--- a/forms.py
+++ b/forms.py
@@ -45,3 +45,12 @@ class StoryForm(FlaskForm):
         FileAllowed(['jpg', 'png', 'jpeg', 'gif', 'mp4', 'mov', 'avi'], 'Images or Videos only!')
     ])
     submit = SubmitField('Post Story')
+
+class ForgotPasswordForm(FlaskForm):
+    email = StringField('Email', validators=[DataRequired(), Email()])
+    submit = SubmitField('Request Password Reset')
+
+class ResetPasswordForm(FlaskForm):
+    password = PasswordField('New Password', validators=[DataRequired(), Length(min=6)])
+    confirm_password = PasswordField('Confirm New Password', validators=[DataRequired(), EqualTo('password')])
+    submit = SubmitField('Reset Password')

--- a/models.py
+++ b/models.py
@@ -1,6 +1,8 @@
 from flask_login import UserMixin
 from app import db
 from datetime import datetime
+from itsdangerous import URLSafeTimedSerializer as Serializer
+from flask import current_app
 
 # Association Table for User <-> Community many-to-many relationship
 community_members = db.Table('community_members',
@@ -48,6 +50,20 @@ class User(UserMixin, db.Model):
     def has_supported_project(self, project):
         return self.supported_projects.filter(
             project_supporters.c.project_id == project.id).count() > 0
+
+    def get_reset_token(self, expires_sec=1800):
+        s = Serializer(current_app.config['SECRET_KEY'])
+        return s.dumps({'user_id': self.id})
+
+    @staticmethod
+    def verify_reset_token(token, expires_sec=1800):
+        s = Serializer(current_app.config['SECRET_KEY'])
+        try:
+            data = s.loads(token, max_age=expires_sec)
+            user_id = data.get('user_id')
+        except Exception:
+            return None
+        return User.query.get(user_id)
 
 class Community(db.Model):
     id = db.Column(db.Integer, primary_key=True)

--- a/templates/auth/forgot_password.html
+++ b/templates/auth/forgot_password.html
@@ -1,0 +1,24 @@
+{% extends "base.html" %}
+{% import 'bootstrap/wtf.html' as wtf %}
+
+{% block content %}
+<div class="container mt-5">
+    <div class="row">
+        <div class="col-md-6 offset-md-3">
+            <div class="card">
+                <div class="card-body">
+                    <h3 class="card-title text-center">Reset Password</h3>
+                    <p class="card-text text-center">Enter your email address and we will send you a link to reset your password.</p>
+                    <form method="POST" action="">
+                        {{ form.hidden_tag() }}
+                        {{ wtf.form_field(form.email) }}
+                        <div class="d-grid gap-2">
+                            {{ wtf.form_field(form.submit, class="btn btn-primary btn-block") }}
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/templates/auth/login.html
+++ b/templates/auth/login.html
@@ -11,7 +11,7 @@
             {{ wtf.form_field(form.password) }}
             {{ wtf.form_field(form.submit) }}
         </form>
-        <p>Forgot your password? <a href="#">Reset Password</a></p>
+        <p>Forgot your password? <a href="{{ url_for('auth.forgot_password') }}">Reset Password</a></p>
     </div>
 </div>
 {% endblock %}

--- a/templates/auth/reset_password.html
+++ b/templates/auth/reset_password.html
@@ -1,0 +1,24 @@
+{% extends "base.html" %}
+{% import 'bootstrap/wtf.html' as wtf %}
+
+{% block content %}
+<div class="container mt-5">
+    <div class="row">
+        <div class="col-md-6 offset-md-3">
+            <div class="card">
+                <div class="card-body">
+                    <h3 class="card-title text-center">Reset Your Password</h3>
+                    <form method="POST" action="">
+                        {{ form.hidden_tag() }}
+                        {{ wtf.form_field(form.password) }}
+                        {{ wtf.form_field(form.confirm_password) }}
+                        <div class="d-grid gap-2">
+                           {{ wtf.form_field(form.submit, class="btn btn-primary btn-block") }}
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
This commit re-implements the "Forgot Password" feature from scratch after a project reset.

- Adds `ForgotPasswordForm` and `ResetPasswordForm` to `forms.py`.
- Adds `get_reset_token` and `verify_reset_token` methods to the `User` model using `itsdangerous` for secure, timed token generation.
- Implements the `/forgot-password` and `/reset-password/<token>` routes in `auth/auth.py`.
- Includes a placeholder function to print the reset link to the console for development purposes.
- Creates the necessary `forgot_password.html` and `reset_password.html` templates.
- Updates the login page to link to the new flow.